### PR TITLE
Update views.py

### DIFF
--- a/couch_docs/views.py
+++ b/couch_docs/views.py
@@ -1,7 +1,6 @@
 from django.http import Http404,HttpResponseRedirect
 from django.shortcuts import render_to_response
-from couchdb import Server
-from couchdb.client import ResourceNotFound
+from couchdb import Server, ResourceNotFound
 
 SERVER = Server('http://127.0.0.1:5984')
 if (len(SERVER) == 0):


### PR DESCRIPTION
The ResourceNotFound exception is no longer located in couchdb.client but directly from couchdb.

> > > from couchdb.client import ResourceNotFound
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > > ImportError: cannot import name ResourceNotFound
> > > from couchdb import ResourceNotFound

I still can't get the tutorial to work on 127.0.0.1:8000 though.
